### PR TITLE
Allow edit games from category

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -68,8 +68,8 @@ class GameActions:
             ("duplicate", _("Duplicate"), self.on_game_duplicate),
             ("configure", _("Configure"), self.on_edit_game_configuration),
             ("favorite", _("Add to favorites"), self.on_add_favorite_game),
-            ("category", _("Categories"), self.on_edit_game_categories),
             ("deletefavorite", _("Remove from favorites"), self.on_delete_favorite_game),
+            ("category", _("Categories"), self.on_edit_game_categories),
             ("execute-script", _("Execute script"), self.on_execute_script_clicked),
             ("browse", _("Browse files"), self.on_browse_files),
             (

--- a/lutris/gui/config/edit_categoriy_games.py
+++ b/lutris/gui/config/edit_categoriy_games.py
@@ -1,0 +1,100 @@
+import locale
+import re
+from gettext import gettext as _
+
+from gi.repository import Gtk
+
+from lutris.gui.config.common import GameDialogCommon
+from lutris.database import categories as categories_db
+from lutris.database import games as games_db
+from lutris.game import Game
+
+
+class EditCategoryGamesDialog(GameDialogCommon):
+    """Games asigned to category dialog."""
+
+    def __init__(self, parent, category):
+        super().__init__(_("Games - %s") % category['name'], parent=parent)
+        self.parent = parent
+
+        self.category = category['name']
+        self.category_id = category['id']
+        self.avaiable_games = [Game(x['id']) for x in games_db.get_games(sorts=[("installed, name", "COLLATE NOCASE DESC")])]
+        self.category_games = [Game(x) for x in categories_db.get_game_ids_for_category(self.category)]
+        self.grid = Gtk.Grid()
+
+        self.set_default_size(350, 250)
+        self.set_border_width(10)
+
+        self.vbox.set_homogeneous(False)
+        self.vbox.set_spacing(10)
+        self.vbox.pack_start(self._create_games_checkboxes(), True, True, 0)
+
+        self.build_action_area(self.on_save)
+        self.show_all()
+
+    def _create_games_checkboxes(self):
+        frame = Gtk.Frame()
+        sw = Gtk.ScrolledWindow()
+        row = Gtk.VBox()
+        category_games_names = [x.name for x in self.category_games]
+        for game in self.avaiable_games:
+            label = game.name
+            checkbutton_option = Gtk.CheckButton(label)
+            if label in category_games_names:
+                checkbutton_option.set_active(True)
+            self.grid.attach_next_to(checkbutton_option, None, Gtk.PositionType.BOTTOM, 3, 1)
+
+        row.pack_start(self.grid, True, True, 0)
+        sw.add_with_viewport(row)
+        frame.add(sw)
+        return frame
+
+    def is_valid(self):
+        return True
+
+    def on_save(self, _button):
+        """Save game info and destroy widget. Return True if success."""
+        if not self.is_valid():
+            return False
+
+        removed_games = []
+        added_games = []
+        category_games_names = [x.name for x in self.category_games]
+        for game_checkbox in self.grid.get_children():
+            label = game_checkbox.get_label()
+            game_id = games_db.get_game_by_field(label, 'name')['id']
+            if label in category_games_names:
+                if not game_checkbox.get_active():
+                    removed_games.append(game_id)
+            else:
+                if game_checkbox.get_active():
+                    added_games.append(game_id)
+
+        for game_id in added_games:
+            game = Game(game_id)
+            game.add_category(self.category)
+            self.parent.on_game_updated(game)
+        for game_id in removed_games:
+            game = Game(game_id)
+            game.remove_category(self.category)
+            self.parent.on_game_updated(game)
+
+        self.destroy()
+
+    # Override the save action box, because we don't need the advanced-checkbox
+    def build_action_area(self, button_callback, callback2=None):
+        self.action_area.set_layout(Gtk.ButtonBoxStyle.END)
+        # Buttons
+        hbox = Gtk.Box()
+        cancel_button = Gtk.Button(label=_("Cancel"))
+        cancel_button.connect("clicked", self.on_cancel_clicked)
+        hbox.pack_start(cancel_button, True, True, 10)
+
+        save_button = Gtk.Button(label=_("Save"))
+        if callback2:
+            save_button.connect("clicked", button_callback, callback2)
+        else:
+            save_button.connect("clicked", button_callback)
+        hbox.pack_start(save_button, True, True, 0)
+        self.action_area.pack_start(hbox, True, True, 0)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -11,6 +11,7 @@ from lutris.game import Game
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
+from lutris.gui.config .edit_categoriy_games import EditCategoryGamesDialog
 from lutris.gui.dialogs import ErrorDialog
 from lutris.gui.dialogs.runner_install import RunnerInstallDialog
 from lutris.gui.widgets.utils import has_stock_icon
@@ -219,16 +220,27 @@ class RunnerSidebarRow(SidebarRow):
 
 class CategorySidebarRow(SidebarRow):
 
-    def __init__(self, category):
+    def __init__(self, category, application):
         super().__init__(
             category['name'],
             "category",
             category['name'],
-            Gtk.Image.new_from_icon_name("folder-symbolic", Gtk.IconSize.MENU)
+            Gtk.Image.new_from_icon_name("folder-symbolic", Gtk.IconSize.MENU),
+            application=application
         )
         self.category = category
 
         self._sort_name = locale.strxfrm(category['name'])
+
+    def get_actions(self):
+        """Return the definition of buttons to be added to the row"""
+        return [
+            ("applications-system-symbolic", _("Edit Games"), self.on_category_clicked, "manage-category-games")
+        ]
+
+    def on_category_clicked(self, button):
+        EditCategoryGamesDialog(self.application.window, self.category)
+        return True
 
     def __lt__(self, other):
         if not isinstance(other, CategorySidebarRow):
@@ -458,7 +470,7 @@ class LutrisSidebar(Gtk.ListBox):
             category_name = category['name']
             # handle added category
             if category_name not in self.category_rows:
-                new_category_row = CategorySidebarRow(category)
+                new_category_row = CategorySidebarRow(category, application=self.application)
                 self.category_rows[category_name] = new_category_row
 
                 # look for proper place to insert new row


### PR DESCRIPTION
Following your work on categories manage from lutris (which I love and i'm using without any issue) I've added a button next to each category to be able to edit directly the games assigned to an specific category. 

It should solve the problem posted by @ntninja:

> Going through our entire library and categorizing all visual novels I would have really liked some way to add more than one game to some category at once – the intuitive way for me would have been to crtl+click on all games I wish to add in the list and then right-click on the last one to open the category editor, but that of course is impossible since the current listview is single-select only

I've also solved the problem noted by @ntninja:

> The Categories menu item is displayed above the Add to favorites one, but below the Remove from favorites one; in effect causing its position in the right-click menu to vary depending on whether the game in question is marked as a favorites or not

Now the "Categories" option is always shown after "Favorites" options.

Some comments about the changes I've made:

- The list of games shown in the new dialog are sorted by "installed, name". So the installed games always are shown on top and then are ordered by name
- You are able to have an empty category by removing all the games from it. I've think about deleting automatically but I've also think we could add a "Remove this category" button in the new dialog. I don't know which would be better.
- As I've already said, the "Categories" option is always shown after the "Favorites" one


Finally, a GIF showing how it looks:

![Peek 2022-12-30 19-39](https://user-images.githubusercontent.com/25721962/210102914-d58914ca-115d-4209-bc5d-b0a9aa76da18.gif)

